### PR TITLE
Prevent auto jump after dig. This fixes popup jump bug

### DIFF
--- a/Assets/scripts/Controller Sets/WHR/WHRPlayerController.cs
+++ b/Assets/scripts/Controller Sets/WHR/WHRPlayerController.cs
@@ -250,6 +250,16 @@ public class WHRPlayerController : PlayerController {
 		movementFrozen = false;
 		GetComponent<Rigidbody2D>().gravityScale = oldGravityScale;
 		GetComponent<BoxCollider2D>().enabled = true;
+		maybeTakeLastAction();
+	}
+	
+	void maybeTakeLastAction() {
+		switch(lastAction) {
+			case "upRight":
+			case "upLeft":
+			case "up":
+				return;
+		}
 		takeAction(lastAction);
 	}
 	
@@ -404,7 +414,7 @@ public class WHRPlayerController : PlayerController {
 	}	
 	
 	void attemptJump() {
-		if(lastJump + 0.1 > Time.realtimeSinceStartup)
+		if(movementFrozen || lastJump + 0.1 > Time.realtimeSinceStartup)
 			return;
 		
 		if(grounded())

--- a/Assets/scripts/Controller Sets/WHR/WHRPlayerController.cs.bak
+++ b/Assets/scripts/Controller Sets/WHR/WHRPlayerController.cs.bak
@@ -250,6 +250,7 @@ public class WHRPlayerController : PlayerController {
 		movementFrozen = false;
 		GetComponent<Rigidbody2D>().gravityScale = oldGravityScale;
 		GetComponent<BoxCollider2D>().enabled = true;
+		takeAction(lastAction);
 	}
 	
 	void attemptDig() {
@@ -403,7 +404,7 @@ public class WHRPlayerController : PlayerController {
 	}	
 	
 	void attemptJump() {
-		if(lastJump + 0.1 > Time.realtimeSinceStartup)
+		if(movementFrozen || lastJump + 0.1 > Time.realtimeSinceStartup)
 			return;
 		
 		if(grounded())


### PR DESCRIPTION
Dig code allows an action to be queued while the character is digging and then taken immediately upon completion (this allows the player to hold a direction down and continue digging). This allowed for a bug when a jump was queued, because firing the jump action immediately upon completion of a dig action could pop the character into a clipping corner where the dug block had been and the character would pop up through the terrain.

This PR prevents that bug by preventing jump actions from being queued while digging.